### PR TITLE
feat: Add Magic The Gathering expert agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ These instructions will get you a copy of the project up and running on your loc
 
 ## Multi-Agent Architecture
 
-This project uses a multi-agent architecture where a `coordination_agent` delegates tasks to specialized sub-agents. The three agents are:
+This project uses a multi-agent architecture where a `coordination_agent` delegates tasks to specialized sub-agents. The four agents are:
 
 ### 1. Coordination Agent
 The `coordination_agent` is the main entry point for user requests. It understands the user's intent and delegates tasks to the appropriate specialist agent. It has the following tools:
 *   `google_search`: Searches the web for information.
 *   `stock_agent`: A sub-agent that is an expert on the stock market.
 *   `background_agent`: A sub-agent for performing long-running tasks.
+*   `magic_agent`: A sub-agent that is an expert on Magic: The Gathering.
 
 ### 2. Stock Agent
 The `stock_agent` is a specialist agent that handles all stock market related queries. It has the following tool:
@@ -84,6 +85,9 @@ The `background_agent` is a sub-agent that can perform long-running tasks, such 
 *   `send_google_chat_message(message: str)`: Sends a message to a Google Chat space. Requires a `GOOGLE_CHAT_WEBHOOK_URL` in the `.env` file.
 *   `print_to_terminal(message: str)`: Prints a message to the terminal where the agent is running.
 *   `stock_agent`: The specialist stock market agent, used for monitoring stock metrics.
+
+### 4. Magic: The Gathering Agent
+The `magic_agent` is a specialist agent that handles all queries about Magic: The Gathering. It has a comprehensive set of tools for interacting with the Scryfall API.
 
 ### Example Usage
 
@@ -103,3 +107,8 @@ The `coordination_agent` will delegate this task to the `background_agent`.
 > "Let me know when the price of GOOGL goes above $150."
 
 The `coordination_agent` will delegate this task to the `background_agent`, which will then use the `stock_agent` to monitor the price.
+
+**Ask a Magic: The Gathering question:**
+> "Search for a card named 'Black Lotus'"
+
+The `coordination_agent` will delegate this task to the `magic_agent`.

--- a/app/coordination_agent/agent.py
+++ b/app/coordination_agent/agent.py
@@ -19,9 +19,11 @@ from google.adk.tools import AgentTool
 from google.adk.tools import google_search
 from app.background_agent.agent import background_agent
 from app.stock_agent.agent import stock_agent
+from app.magic_agent.agent import magic_agent
 
 background_agent_tool = AgentTool(agent=background_agent)
 stock_agent_tool = AgentTool(agent=stock_agent)
+magic_agent_tool = AgentTool(agent=magic_agent)
 
 root_agent = Agent(
     name='coordination_agent',
@@ -35,7 +37,9 @@ root_agent = Agent(
         'If a user asks for a task to be performed in the background, '
         'such as waiting and then sending a notification, you must use the '
         'background_agent tool. If a user asks a question about the stock '
-        'market, you must use the stock_agent tool.'
+        'market, you must use the stock_agent tool. If a user asks a '
+        'question about Magic: The Gathering, you must use the magic_agent '
+        'tool.'
     ),
-    tools=[google_search, background_agent_tool, stock_agent_tool],
+    tools=[google_search, background_agent_tool, stock_agent_tool, magic_agent_tool],
 )

--- a/app/magic_agent/__init__.py
+++ b/app/magic_agent/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Initializes the magic_agent package."""
+
+from . import agent

--- a/app/magic_agent/agent.py
+++ b/app/magic_agent/agent.py
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Defines the Magic: The Gathering expert agent."""
+
+from google.adk.agents import LlmAgent
+from app.tools import scryfall_tool
+
+magic_agent = LlmAgent(
+    name='magic_agent',
+    model='gemini-1.5-flash',
+    description='An agent that is an expert on Magic: The Gathering.',
+    instruction=(
+        'You are an expert on Magic: The Gathering. Your purpose is to provide '
+        'information about cards, sets, and other game-related topics. You must '
+        'use the available tools to answer any questions.'
+    ),
+    tools=scryfall_tool.all_scryfall_tools,
+)

--- a/app/tools/scryfall_tool.py
+++ b/app/tools/scryfall_tool.py
@@ -339,3 +339,22 @@ get_set_by_id_tool = Tool(
     description="Gets a set by its Scryfall ID.",
     func=get_set_by_id,
 )
+
+all_scryfall_tools = [
+    search_cards_tool,
+    get_card_by_name_tool,
+    get_random_card_tool,
+    get_card_by_id_tool,
+    autocomplete_card_name_tool,
+    get_card_collection_tool,
+    get_card_by_code_and_number_tool,
+    get_card_by_multiverse_id_tool,
+    get_card_by_mtgo_id_tool,
+    get_card_by_arena_id_tool,
+    get_card_by_tcgplayer_id_tool,
+    get_card_by_cardmarket_id_tool,
+    get_all_sets_tool,
+    get_set_by_code_tool,
+    get_set_by_tcgplayer_id_tool,
+    get_set_by_id_tool,
+]


### PR DESCRIPTION
This commit introduces a new specialized agent that is an expert on Magic: The Gathering.

This new `magic_agent` is equipped with a comprehensive set of tools for interacting with the Scryfall API, allowing it to answer questions about cards and sets.

The `coordination_agent` has been updated to delegate all Magic: The Gathering related queries to this new expert agent. The `README.md` has also been updated to reflect this new capability.